### PR TITLE
package name consistent with name on package index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Adapted from: http://www.greghendershott.com/2017/04/racket-makefiles.html
-PACKAGE-NAME=qi-quickscripts
+PACKAGE-NAME=Qi-Quickscripts
 
 DEPS-FLAGS=--check-pkg-deps --unused-pkg-deps
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ make it easier to work with
 
 ## 1. Installation
 
-In DrRacket, in `File|Package manager|Source`, enter `qi-quickscripts`.
+In DrRacket, in `File|Package manager|Source`, enter `Qi-Quickscripts`.
 
-Or, on the command line, type: `raco pkg install qi-quickscripts`.
+Or, on the command line, type: `raco pkg install Qi-Quickscripts`.
 
 If DrRacket is already running, click on `Scripts|Manage scripts|Compile
 scripts`.

--- a/scribblings/qi-quickscripts.scrbl
+++ b/scribblings/qi-quickscripts.scrbl
@@ -25,9 +25,9 @@ to make it easier to work with @(hyperlink "https://docs.racket-lang.org/qi/inde
 
 @section{Installation}
 
-In DrRacket, in @tt{File|Package manager|Source}, enter @tt{qi-quickscripts}.
+In DrRacket, in @tt{File|Package manager|Source}, enter @tt{Qi-Quickscripts}.
 
-Or, on the command line, type: @tt{raco pkg install qi-quickscripts}.
+Or, on the command line, type: @tt{raco pkg install Qi-Quickscripts}.
 
 If DrRacket is already running, click on @tt{Scripts|Manage scripts|Compile scripts}.
 
@@ -76,7 +76,7 @@ The shadow script calls the original script without modifying it, and can be mod
 without being modified when the original script is updated.
 
 In particular, if you want to change the default label, menu path or keybinding of a script installed
-from @tt{quickscript-extra}, go to @tt{Scripts|Manage|Library…}, select the @tt{qi-quickscripts}
+from @tt{quickscript-extra}, go to @tt{Scripts|Manage|Library…}, select the @tt{Qi-Quickscripts}
 directory, then the script you want, and click on @tt{Shadow}.
 This opens a new (shadow) script that calls the original script where you can change what you want.
 


### PR DESCRIPTION
This is one way to fix #2 
With this change the github project name is still inconsistent,
which sadly means that when you just use the github clone copy&paste `git@github.com:spdegabrielle/qi-quickscripts.git` followed by `raco pkg install` in that directory you end up with a `qi-quickscripts` package name, while it is named `Qi-Quickscripts` if you install via package index via `raco pkg install Qi-Quickscripts`.

I am not sure what would be better:
1. this pull request + rename this git repository to start with uppercase & a quick syncronized update of the package index pathes/meta-info.
2. Or the other way around change everything to lowercase, but that would mean dependencies have to change, which seems like a bigger problem than 1.

Creating a draft pull request, because I want feedback on this, I think 1. could work well.